### PR TITLE
OPHJOD-1924: Replace all references to Artikkeli so that they use articleECR (string) instead of articleId (long)

### DIFF
--- a/src/main/java/fi/okm/jod/ohjaaja/controller/ArtikkelinKommenttiController.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/controller/ArtikkelinKommenttiController.java
@@ -35,10 +35,10 @@ public class ArtikkelinKommenttiController {
   @GetMapping
   @Operation(summary = "Finds all artikkelin kommentit")
   SivuDto<ArtikkelinKommenttiDto> findAllArtikkelinKommentit(
-      @RequestParam long artikkeliId, @RequestParam int sivu, @RequestParam int koko) {
+      @RequestParam String artikkeliErc, @RequestParam int sivu, @RequestParam int koko) {
 
-    return service.findByArtikkeliId(
-        artikkeliId, PageRequest.of(sivu, koko, Sort.by(Sort.Direction.DESC, "luotu")));
+    return service.findByArtikkeliErc(
+        artikkeliErc, PageRequest.of(sivu, koko, Sort.by(Sort.Direction.DESC, "luotu")));
   }
 
   @PostMapping
@@ -46,7 +46,7 @@ public class ArtikkelinKommenttiController {
   ArtikkelinKommenttiDto createArtikkelinKommentti(
       @AuthenticationPrincipal JodUser user,
       @Validated(Add.class) @RequestBody ArtikkelinKommenttiDto kommenttiDto) {
-    return service.add(user, kommenttiDto.artikkeliId(), kommenttiDto.kommentti());
+    return service.add(user, kommenttiDto.artikkeliErc(), kommenttiDto.kommentti());
   }
 
   @DeleteMapping("/{id}")

--- a/src/main/java/fi/okm/jod/ohjaaja/controller/profiili/ArtikkelinKatseluController.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/controller/profiili/ArtikkelinKatseluController.java
@@ -30,25 +30,25 @@ import org.springframework.web.bind.annotation.*;
 public class ArtikkelinKatseluController {
   private final ArtikkelinKatseluService service;
 
-  @PostMapping("/katselu/{artikkeliId}")
+  @PostMapping("/katselu/{artikkeliErc}")
   @Operation(summary = "Adds a Katselu to the Artikkeli")
-  void add(@AuthenticationPrincipal JodUser jodUser, @PathVariable long artikkeliId) {
-    service.add(jodUser, artikkeliId);
+  void add(@AuthenticationPrincipal JodUser jodUser, @PathVariable String artikkeliErc) {
+    service.add(jodUser, artikkeliErc);
   }
 
   @GetMapping("/katselu/katsotuimmat")
-  @Operation(summary = "Gets the most viewed article ids")
-  SivuDto<Long> getMostViewedArtikkeliIds(
-      @Nullable @RequestParam List<Long> filterByArtikkeliIds,
+  @Operation(summary = "Gets the most viewed article Ercs")
+  SivuDto<String> getMostViewedArtikkeliIds(
+      @Nullable @RequestParam List<String> filterByArtikkeliErcs,
       @RequestParam(defaultValue = "12") int koko) {
-    return service.findMostViewedArtikkeliIds(
-        filterByArtikkeliIds, PageRequest.of(0, koko, Sort.by(Sort.Direction.DESC, "summa")));
+    return service.findMostViewedArtikkeliErcs(
+        filterByArtikkeliErcs, PageRequest.of(0, koko, Sort.by(Sort.Direction.DESC, "summa")));
   }
 
   @GetMapping("/viimeksi-katsellut")
-  @Operation(summary = "Gets the last viewed article ids")
-  SivuDto<Long> getMostRecentViewedArtikkeliIds(
+  @Operation(summary = "Gets the last viewed article Ercs")
+  SivuDto<String> getMostRecentViewedArtikkeliIds(
       @AuthenticationPrincipal JodUser jodUser, @RequestParam(defaultValue = "20") int koko) {
-    return service.findMostRecentViewedArtikkeliIdsByUser(jodUser, Pageable.ofSize(koko));
+    return service.findMostRecentViewedArtikkeliErcsByUser(jodUser, Pageable.ofSize(koko));
   }
 }

--- a/src/main/java/fi/okm/jod/ohjaaja/controller/profiili/OhjaajanSuosikkiController.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/controller/profiili/OhjaajanSuosikkiController.java
@@ -40,7 +40,7 @@ public class OhjaajanSuosikkiController {
   @Operation(summary = "Add a new Ohjaaja's suosikki")
   UUID add(
       @AuthenticationPrincipal JodUser user, @Validated(Add.class) @RequestBody SuosikkiDto dto) {
-    return service.add(user, dto.artikkeliId());
+    return service.add(user, dto.artikkeliErc());
   }
 
   @DeleteMapping

--- a/src/main/java/fi/okm/jod/ohjaaja/dto/ArtikkelinKommenttiDto.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/dto/ArtikkelinKommenttiDto.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 
 public record ArtikkelinKommenttiDto(
     @Null(groups = Add.class) @Schema(accessMode = Schema.AccessMode.READ_ONLY) UUID id,
-    @NotNull long artikkeliId,
+    @NotNull String artikkeliErc,
     @Null(groups = Add.class) @Schema(accessMode = Schema.AccessMode.READ_ONLY) UUID ohjaajaId,
     @NotNull @NotBlank @Size(max = 2000) String kommentti,
     @Null(groups = Add.class) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant luotu) {}

--- a/src/main/java/fi/okm/jod/ohjaaja/dto/profiili/SuosikkiDto.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/dto/profiili/SuosikkiDto.java
@@ -18,5 +18,5 @@ import java.util.UUID;
 
 public record SuosikkiDto(
     @Null(groups = Add.class) @Schema(accessMode = Schema.AccessMode.READ_ONLY) UUID id,
-    @NotNull Long artikkeliId,
+    @NotNull String artikkeliErc,
     @Null(groups = Add.class) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant luotu) {}

--- a/src/main/java/fi/okm/jod/ohjaaja/dto/profiili/export/ArtikkelinKommenttiExportDto.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/dto/profiili/export/ArtikkelinKommenttiExportDto.java
@@ -13,4 +13,4 @@ import java.time.Instant;
 import java.util.UUID;
 
 public record ArtikkelinKommenttiExportDto(
-    UUID id, Instant luotu, long artikkeliId, String kommentti) {}
+    UUID id, Instant luotu, String artikkeliErc, String kommentti) {}

--- a/src/main/java/fi/okm/jod/ohjaaja/dto/profiili/export/OhjaajanSuosikkiExportDto.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/dto/profiili/export/OhjaajanSuosikkiExportDto.java
@@ -12,4 +12,4 @@ package fi.okm.jod.ohjaaja.dto.profiili.export;
 import java.time.Instant;
 import java.util.UUID;
 
-public record OhjaajanSuosikkiExportDto(UUID id, Instant luotu, Long artikkeliId) {}
+public record OhjaajanSuosikkiExportDto(UUID id, Instant luotu, String artikkeliErc) {}

--- a/src/main/java/fi/okm/jod/ohjaaja/entity/ArtikkelinKatselu.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/entity/ArtikkelinKatselu.java
@@ -23,8 +23,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ArtikkelinKatselu {
   @Id
-  @Column(name = "artikkeli_id", nullable = false)
-  private Long artikkeliId;
+  @Column(name = "artikkeli_erc", nullable = false)
+  private String artikkeliErc;
 
   @Id
   @Column(name = "paiva", nullable = false)

--- a/src/main/java/fi/okm/jod/ohjaaja/entity/ArtikkelinKatseluId.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/entity/ArtikkelinKatseluId.java
@@ -27,18 +27,18 @@ import lombok.Setter;
 public class ArtikkelinKatseluId implements Serializable {
 
   @Serial private static final long serialVersionUID = 1L;
-  private Long artikkeliId;
+  private String artikkeliErc;
   private LocalDate paiva;
 
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (!(o instanceof ArtikkelinKatseluId that)) return false;
-    return Objects.equals(artikkeliId, that.artikkeliId) && Objects.equals(paiva, that.paiva);
+    return Objects.equals(artikkeliErc, that.artikkeliErc) && Objects.equals(paiva, that.paiva);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(artikkeliId, paiva);
+    return Objects.hash(artikkeliErc, paiva);
   }
 }

--- a/src/main/java/fi/okm/jod/ohjaaja/entity/ArtikkelinKommentti.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/entity/ArtikkelinKommentti.java
@@ -21,7 +21,7 @@ import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
-@Table(indexes = {@Index(columnList = "ohjaaja_id"), @Index(columnList = "artikkeli_id")})
+@Table(indexes = {@Index(columnList = "ohjaaja_id"), @Index(columnList = "artikkeli_erc")})
 @AllArgsConstructor
 @NoArgsConstructor
 public class ArtikkelinKommentti {
@@ -35,8 +35,8 @@ public class ArtikkelinKommentti {
   @OnDelete(action = OnDeleteAction.SET_NULL)
   private Ohjaaja ohjaaja;
 
-  @Column(updatable = false, nullable = false)
-  private Long artikkeliId;
+  @Column(name = "artikkeli_erc", updatable = false, nullable = false)
+  private String artikkeliErc;
 
   @Column(updatable = false, nullable = false)
   private Instant luotu;
@@ -47,9 +47,9 @@ public class ArtikkelinKommentti {
   @OneToMany(mappedBy = "artikkelinKommentti", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   private Set<ArtikkelinKommentinIlmianto> ilmiannot;
 
-  public ArtikkelinKommentti(Ohjaaja ohjaaja, Long artikkeliId, String kommentti) {
+  public ArtikkelinKommentti(Ohjaaja ohjaaja, String artikkeliErc, String kommentti) {
     this.ohjaaja = ohjaaja;
-    this.artikkeliId = artikkeliId;
+    this.artikkeliErc = artikkeliErc;
     this.kommentti = kommentti;
     this.luotu = Instant.now();
   }

--- a/src/main/java/fi/okm/jod/ohjaaja/entity/OhjaajanSuosikki.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/entity/OhjaajanSuosikki.java
@@ -31,11 +31,11 @@ public class OhjaajanSuosikki {
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   private Ohjaaja ohjaaja;
 
-  @Column(updatable = false, nullable = false)
-  private Long artikkeliId;
+  @Column(name = "artikkeli_erc", updatable = false, nullable = false)
+  private String artikkeliErc;
 
-  public OhjaajanSuosikki(Long artikkeliId, Ohjaaja ohjaaja) {
-    this.artikkeliId = artikkeliId;
+  public OhjaajanSuosikki(String artikkeliErc, Ohjaaja ohjaaja) {
+    this.artikkeliErc = artikkeliErc;
     this.ohjaaja = ohjaaja;
     this.luotu = Instant.now();
   }

--- a/src/main/java/fi/okm/jod/ohjaaja/entity/ViimeksiKatseltuArtikkeli.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/entity/ViimeksiKatseltuArtikkeli.java
@@ -21,15 +21,15 @@ import lombok.Setter;
 @Getter
 @Table(
     indexes = {@Index(columnList = "ohjaaja_id")},
-    uniqueConstraints = {@UniqueConstraint(columnNames = {"artikkeli_id", "ohjaaja_id"})})
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"artikkeli_erc", "ohjaaja_id"})})
 @AllArgsConstructor
 @NoArgsConstructor
 public class ViimeksiKatseltuArtikkeli {
 
   @Id @GeneratedValue private Long id;
 
-  @Column(name = "artikkeli_id", nullable = false)
-  private Long artikkeliId;
+  @Column(name = "artikkeli_erc", nullable = false)
+  private String artikkeliErc;
 
   @Column(name = "ohjaaja_id", nullable = false)
   private UUID ohjaajaId;
@@ -38,8 +38,8 @@ public class ViimeksiKatseltuArtikkeli {
   @Column(name = "viimeksi_katseltu", nullable = false)
   private Instant viimeksiKatseltu;
 
-  public ViimeksiKatseltuArtikkeli(Long artikkeliId, UUID ohjaajaId) {
-    this.artikkeliId = artikkeliId;
+  public ViimeksiKatseltuArtikkeli(String artikkeliErc, UUID ohjaajaId) {
+    this.artikkeliErc = artikkeliErc;
     this.ohjaajaId = ohjaajaId;
     this.viimeksiKatseltu = Instant.now();
   }

--- a/src/main/java/fi/okm/jod/ohjaaja/repository/ArtikkelinKatseluRepository.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/repository/ArtikkelinKatseluRepository.java
@@ -29,21 +29,21 @@ public interface ArtikkelinKatseluRepository
   @Query(
       value =
           """
-              INSERT INTO artikkelin_katselu (artikkeli_id, paiva, maara)
-              VALUES (:artikkeliId, :paiva, 1)
-              ON CONFLICT (artikkeli_id, paiva)
+              INSERT INTO artikkelin_katselu (artikkeli_erc, paiva, maara)
+              VALUES (:artikkeliErc, :paiva, 1)
+              ON CONFLICT (artikkeli_erc, paiva)
               DO UPDATE SET maara = artikkelin_katselu.maara + 1
               """,
       nativeQuery = true)
-  void upsertKatselu(Long artikkeliId, LocalDate paiva);
+  void upsertKatselu(String artikkeliErc, LocalDate paiva);
 
   @Query(
       """
-      SELECT ak.artikkeliId AS artikkeliId, SUM(ak.maara) AS summa
+      SELECT ak.artikkeliErc AS artikkeliErc, SUM(ak.maara) AS summa
       FROM ArtikkelinKatselu ak
-      WHERE (:artikkeliIds IS NULL OR ak.artikkeliId IN :artikkeliIds)
-      GROUP BY ak.artikkeliId
+      WHERE (:artikkeliErcs IS NULL OR ak.artikkeliErc IN :artikkeliErcs)
+      GROUP BY ak.artikkeliErc
       """)
   Page<SummaPerArtikkeli> findSumKatselut(
-      @Nullable Collection<Long> artikkeliIds, Pageable pageable);
+      @Nullable Collection<String> artikkeliErcs, Pageable pageable);
 }

--- a/src/main/java/fi/okm/jod/ohjaaja/repository/ArtikkelinKommenttiRepository.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/repository/ArtikkelinKommenttiRepository.java
@@ -17,5 +17,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArtikkelinKommenttiRepository extends JpaRepository<ArtikkelinKommentti, UUID> {
 
-  Page<ArtikkelinKommentti> findByArtikkeliId(Long artikkeliId, Pageable pageable);
+  Page<ArtikkelinKommentti> findByArtikkeliErc(String artikkeliErc, Pageable pageable);
 }

--- a/src/main/java/fi/okm/jod/ohjaaja/repository/OhjaajanSuosikkiRepository.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/repository/OhjaajanSuosikkiRepository.java
@@ -21,5 +21,5 @@ public interface OhjaajanSuosikkiRepository extends JpaRepository<OhjaajanSuosik
 
   List<OhjaajanSuosikki> findByOhjaaja(Ohjaaja ohjaaja);
 
-  Optional<OhjaajanSuosikki> findByOhjaajaAndArtikkeliId(Ohjaaja ohjaaja, Long artikkeliId);
+  Optional<OhjaajanSuosikki> findByOhjaajaAndArtikkeliErc(Ohjaaja ohjaaja, String artikkeliErc);
 }

--- a/src/main/java/fi/okm/jod/ohjaaja/repository/ViimeksiKatseltuArtikkeliRepository.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/repository/ViimeksiKatseltuArtikkeliRepository.java
@@ -18,8 +18,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ViimeksiKatseltuArtikkeliRepository
     extends JpaRepository<ViimeksiKatseltuArtikkeli, Long> {
-  Optional<ViimeksiKatseltuArtikkeli> findByArtikkeliIdAndOhjaajaId(
-      Long artikkeliId, UUID ohjaajaId);
+  Optional<ViimeksiKatseltuArtikkeli> findByArtikkeliErcAndOhjaajaId(
+      String artikkeliErc, UUID ohjaajaId);
 
   Page<ViimeksiKatseltuArtikkeli> findByOhjaajaIdOrderByViimeksiKatseltuDesc(
       UUID ohjaajaId, Pageable pageable);

--- a/src/main/java/fi/okm/jod/ohjaaja/repository/projection/SummaPerArtikkeli.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/repository/projection/SummaPerArtikkeli.java
@@ -10,7 +10,7 @@
 package fi.okm.jod.ohjaaja.repository.projection;
 
 public interface SummaPerArtikkeli {
-  long getArtikkeliId();
+  String getArtikkeliErc();
 
   long getSumma();
 }

--- a/src/main/java/fi/okm/jod/ohjaaja/service/ArtikkelinKommenttiMapper.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/service/ArtikkelinKommenttiMapper.java
@@ -23,7 +23,7 @@ public final class ArtikkelinKommenttiMapper {
         ? null
         : new ArtikkelinKommenttiDto(
             entity.getId(),
-            entity.getArtikkeliId(),
+            entity.getArtikkeliErc(),
             Optional.ofNullable(entity.getOhjaaja()).map(Ohjaaja::getId).orElse(null),
             entity.getKommentti(),
             entity.getLuotu());

--- a/src/main/java/fi/okm/jod/ohjaaja/service/ArtikkelinKommenttiService.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/service/ArtikkelinKommenttiService.java
@@ -44,10 +44,10 @@ public class ArtikkelinKommenttiService {
 
   @FeatureRequired(FeatureFlag.Feature.COMMENTS)
   public ArtikkelinKommenttiDto add(
-      @NotNull JodUser jodUser, long artikkeliId, @NotNull String kommentti) {
+      @NotNull JodUser jodUser, @NotNull String artikkeliErc, @NotNull String kommentti) {
     var cleanedKommentti = clean(kommentti, "", Safelist.relaxed(), outputSettings);
     var ohjaaja = ohjaajat.getReferenceById(jodUser.getId());
-    var artikkelinKommentti = new ArtikkelinKommentti(ohjaaja, artikkeliId, cleanedKommentti);
+    var artikkelinKommentti = new ArtikkelinKommentti(ohjaaja, artikkeliErc, cleanedKommentti);
     return ArtikkelinKommenttiMapper.mapArtikkelinKommentti(
         artikkelinKommentit.save(artikkelinKommentti));
   }
@@ -62,8 +62,9 @@ public class ArtikkelinKommenttiService {
   }
 
   @FeatureRequired(FeatureFlag.Feature.COMMENTS)
-  public SivuDto<ArtikkelinKommenttiDto> findByArtikkeliId(long artikkeliId, Pageable pageable) {
-    var kommentit = artikkelinKommentit.findByArtikkeliId(artikkeliId, pageable);
+  public SivuDto<ArtikkelinKommenttiDto> findByArtikkeliErc(
+      String artikkeliErc, Pageable pageable) {
+    var kommentit = artikkelinKommentit.findByArtikkeliErc(artikkeliErc, pageable);
     return new SivuDto<>(
         kommentit.map(ArtikkelinKommenttiMapper::mapArtikkelinKommentti).getContent(),
         kommentit.getTotalElements(),

--- a/src/main/java/fi/okm/jod/ohjaaja/service/profiili/ExportMapper.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/service/profiili/ExportMapper.java
@@ -43,7 +43,8 @@ public final class ExportMapper {
   public static OhjaajanSuosikkiExportDto mapOhjaajanSuosikki(OhjaajanSuosikki entity) {
     return entity == null
         ? null
-        : new OhjaajanSuosikkiExportDto(entity.getId(), entity.getLuotu(), entity.getArtikkeliId());
+        : new OhjaajanSuosikkiExportDto(
+            entity.getId(), entity.getLuotu(), entity.getArtikkeliErc());
   }
 
   public static OhjaajanKiinnostusExportDto mapOhjaajanKiinnostus(OhjaajanKiinnostus entity) {
@@ -57,6 +58,6 @@ public final class ExportMapper {
     return entity == null
         ? null
         : new ArtikkelinKommenttiExportDto(
-            entity.getId(), entity.getLuotu(), entity.getArtikkeliId(), entity.getKommentti());
+            entity.getId(), entity.getLuotu(), entity.getArtikkeliErc(), entity.getKommentti());
   }
 }

--- a/src/main/java/fi/okm/jod/ohjaaja/service/profiili/OhjaajanSuosikkiService.java
+++ b/src/main/java/fi/okm/jod/ohjaaja/service/profiili/OhjaajanSuosikkiService.java
@@ -33,16 +33,16 @@ public class OhjaajanSuosikkiService {
     return suosikit.findByOhjaaja(ohjaaja).stream()
         .map(
             suosikki ->
-                new SuosikkiDto(suosikki.getId(), suosikki.getArtikkeliId(), suosikki.getLuotu()))
+                new SuosikkiDto(suosikki.getId(), suosikki.getArtikkeliErc(), suosikki.getLuotu()))
         .toList();
   }
 
-  public UUID add(JodUser user, Long artikkeliId) {
+  public UUID add(JodUser user, String artikkeliErc) {
     var ohjaaja = ohjaajat.getReferenceById(user.getId());
     return suosikit
-        .findByOhjaajaAndArtikkeliId(ohjaaja, artikkeliId)
+        .findByOhjaajaAndArtikkeliErc(ohjaaja, artikkeliErc)
         .map(OhjaajanSuosikki::getId)
-        .orElseGet(() -> suosikit.save(new OhjaajanSuosikki(artikkeliId, ohjaaja)).getId());
+        .orElseGet(() -> suosikit.save(new OhjaajanSuosikki(artikkeliErc, ohjaaja)).getId());
   }
 
   public void delete(JodUser user, UUID id) {

--- a/src/test/java/fi/okm/jod/ohjaaja/service/ArtikkelinKatseluServiceTest.java
+++ b/src/test/java/fi/okm/jod/ohjaaja/service/ArtikkelinKatseluServiceTest.java
@@ -31,13 +31,13 @@ class ArtikkelinKatseluServiceTest extends AbstractServiceTest {
 
   @Test
   void shouldAddOnlyArtikkelinKatseluWhenUserIsNull() {
-    var artikkeliId = 1L;
-    service.add(null, artikkeliId);
+    final var artikkeliErc = "external-reference-code";
+    service.add(null, artikkeliErc);
 
     var artikkelinKatselut = artikkelinKatseluRepository.findAll();
     assertEquals(1, artikkelinKatselut.size());
     var katselu = artikkelinKatselut.getFirst();
-    assertEquals(1L, katselu.getArtikkeliId());
+    assertEquals(artikkeliErc, katselu.getArtikkeliErc());
     assertEquals(1, katselu.getMaara());
     assertEquals(LocalDate.now(), katselu.getPaiva());
 
@@ -47,120 +47,121 @@ class ArtikkelinKatseluServiceTest extends AbstractServiceTest {
 
   @Test
   void shouldAddArtikkelinKatseluAndViimeksiKatseltuWhenUserIsLoggedIn() {
-    var artikkeliId = 1L;
-    service.add(user, artikkeliId);
+    final var artikkeliErc = "external-reference-code";
+    service.add(user, artikkeliErc);
 
     var artikkelinKatselut = artikkelinKatseluRepository.findAll();
     assertEquals(1, artikkelinKatselut.size());
     var katselu = artikkelinKatselut.getFirst();
-    assertEquals(1L, katselu.getArtikkeliId());
+    assertEquals(artikkeliErc, katselu.getArtikkeliErc());
     assertEquals(1, katselu.getMaara());
     assertEquals(LocalDate.now(), katselu.getPaiva());
 
     var viimeksiKatsellut =
-        viimeksiKatseltuArtikkeliRepository.findByArtikkeliIdAndOhjaajaId(
-            artikkeliId, user.getId());
+        viimeksiKatseltuArtikkeliRepository.findByArtikkeliErcAndOhjaajaId(
+            artikkeliErc, user.getId());
     assertTrue(viimeksiKatsellut.isPresent());
-    assertEquals(artikkeliId, viimeksiKatsellut.get().getArtikkeliId());
+    assertEquals(artikkeliErc, viimeksiKatsellut.get().getArtikkeliErc());
     assertEquals(user.getId(), viimeksiKatsellut.get().getOhjaajaId());
     assertNotNull(viimeksiKatsellut.get().getViimeksiKatseltu());
   }
 
   @Test
-  void shouldIncreaseMaaraWhenArtikkeliIdAlreadyExists() {
-    var artikkeliId = 1L;
-    service.add(user, artikkeliId);
-    service.add(user, artikkeliId);
+  void shouldIncreaseMaaraWhenartikkeliErcAlreadyExists() {
+    final var artikkeliErc = "external-reference-code";
+    service.add(user, artikkeliErc);
+    service.add(user, artikkeliErc);
 
     var artikkelinKatselut = artikkelinKatseluRepository.findAll();
     assertEquals(1, artikkelinKatselut.size());
     var katselu = artikkelinKatselut.getFirst();
-    assertEquals(artikkeliId, katselu.getArtikkeliId());
+    assertEquals(artikkeliErc, katselu.getArtikkeliErc());
     assertEquals(2, katselu.getMaara());
   }
 
   @Test
-  void shouldNotAddArtikkelinKatseluWhenArtikkeliIdIsNull() {
+  void shouldNotAddArtikkelinKatseluWhenartikkeliErcIsNull() {
     assertThrows(IllegalArgumentException.class, () -> service.add(null, null));
   }
 
   @Test
   void shouldReturnEmptySetWhenNoArtikkelinKatseluExists() {
-    var result = service.findMostRecentViewedArtikkeliIdsByUser(user, Pageable.ofSize(20));
+    var result = service.findMostRecentViewedArtikkeliErcsByUser(user, Pageable.ofSize(20));
     assertEquals(0, result.maara());
   }
 
   @Test
-  void shouldRetrieveMostRecentViewedArtikkeliId() {
+  void shouldRetrieveMostRecentViewedartikkeliErc() {
 
-    var artikkeliId = 1L;
-    service.add(user, artikkeliId);
+    final var artikkeliErc = "external-reference-code";
+    service.add(user, artikkeliErc);
 
-    var result = service.findMostRecentViewedArtikkeliIdsByUser(user, Pageable.ofSize(20));
+    var result = service.findMostRecentViewedArtikkeliErcsByUser(user, Pageable.ofSize(20));
     assertEquals(1, result.maara());
-    assertEquals(1L, result.sisalto().getFirst());
+    assertEquals(artikkeliErc, result.sisalto().getFirst());
   }
 
   @Test
-  void shouldReturnMostRecentArtikkeliIdsInOrder() {
-    var artikkeliId1 = 1L;
-    var artikkeliId2 = 2L;
-    var artikkeliId3 = 3L;
+  void shouldReturnMostRecentartikkeliErcsInOrder() {
+    final var artikkeliErc1 = "external-reference-code1";
+    final var artikkeliErc2 = "external-reference-code2";
+    final var artikkeliErc3 = "external-reference-code3";
 
-    service.add(user, artikkeliId1);
-    service.add(user, artikkeliId2);
-    service.add(user, artikkeliId3);
-    service.add(user, artikkeliId2);
+    service.add(user, artikkeliErc1);
+    service.add(user, artikkeliErc2);
+    service.add(user, artikkeliErc3);
+    service.add(user, artikkeliErc2);
 
-    var result = service.findMostRecentViewedArtikkeliIdsByUser(user, Pageable.ofSize(20));
+    var result = service.findMostRecentViewedArtikkeliErcsByUser(user, Pageable.ofSize(20));
 
     assertEquals(3, result.maara());
-    assertEquals(artikkeliId2, result.sisalto().getFirst());
-    assertEquals(artikkeliId3, result.sisalto().get(1));
-    assertEquals(artikkeliId1, result.sisalto().get(2));
+    assertEquals(artikkeliErc2, result.sisalto().getFirst());
+    assertEquals(artikkeliErc3, result.sisalto().get(1));
+    assertEquals(artikkeliErc1, result.sisalto().get(2));
   }
 
   @Test
-  void shouldReturnMostViewedArtikkeliIds() {
-    var artikkeliId1 = 1L;
-    var artikkeliId2 = 2L;
-    var artikkeliId3 = 3L;
+  void shouldReturnMostViewedartikkeliErcs() {
+    final var artikkeliErc1 = "external-reference-code1";
+    final var artikkeliErc2 = "external-reference-code2";
+    final var artikkeliErc3 = "external-reference-code3";
 
-    service.add(user, artikkeliId1);
-    service.add(user, artikkeliId2);
-    service.add(user, artikkeliId3);
-    service.add(user, artikkeliId2);
-    service.add(user, artikkeliId2);
-    service.add(user, artikkeliId1);
+    service.add(user, artikkeliErc1);
+    service.add(user, artikkeliErc2);
+    service.add(user, artikkeliErc3);
+    service.add(user, artikkeliErc2);
+    service.add(user, artikkeliErc2);
+    service.add(user, artikkeliErc1);
 
     var pageable = PageRequest.of(0, 12, Sort.by(Sort.Direction.DESC, "summa"));
 
-    var result = service.findMostViewedArtikkeliIds(null, pageable);
+    var result = service.findMostViewedArtikkeliErcs(null, pageable);
 
     assertEquals(3, result.maara());
-    assertEquals(artikkeliId2, result.sisalto().getFirst());
-    assertEquals(artikkeliId1, result.sisalto().get(1));
-    assertEquals(artikkeliId3, result.sisalto().get(2));
+    assertEquals(artikkeliErc2, result.sisalto().getFirst());
+    assertEquals(artikkeliErc1, result.sisalto().get(1));
+    assertEquals(artikkeliErc3, result.sisalto().get(2));
   }
 
   @Test
-  void shouldReturnMostViewedArtikkeliIdsFilteredByIds() {
-    var artikkeliId1 = 1L;
-    var artikkeliId2 = 2L;
-    var artikkeliId3 = 3L;
+  void shouldReturnMostViewedartikkeliErcsFilteredByIds() {
+    final var artikkeliErc1 = "external-reference-code1";
+    final var artikkeliErc2 = "external-reference-code2";
+    final var artikkeliErc3 = "external-reference-code3";
 
-    service.add(null, artikkeliId1);
-    service.add(null, artikkeliId2);
-    service.add(null, artikkeliId3);
-    service.add(null, artikkeliId2);
+    service.add(null, artikkeliErc1);
+    service.add(null, artikkeliErc2);
+    service.add(null, artikkeliErc3);
+    service.add(null, artikkeliErc2);
 
     var pageable = PageRequest.of(0, 12, Sort.by(Sort.Direction.DESC, "summa"));
 
-    var result = service.findMostViewedArtikkeliIds(List.of(artikkeliId1, artikkeliId2), pageable);
+    var result =
+        service.findMostViewedArtikkeliErcs(List.of(artikkeliErc1, artikkeliErc2), pageable);
 
     assertEquals(2, result.maara());
-    assertEquals(artikkeliId2, result.sisalto().getFirst());
-    assertEquals(artikkeliId1, result.sisalto().get(1));
+    assertEquals(artikkeliErc2, result.sisalto().getFirst());
+    assertEquals(artikkeliErc1, result.sisalto().get(1));
   }
 
   @Test
@@ -168,7 +169,7 @@ class ArtikkelinKatseluServiceTest extends AbstractServiceTest {
 
     var pageable = PageRequest.of(0, 12, Sort.by(Sort.Direction.DESC, "summa"));
 
-    var result = service.findMostViewedArtikkeliIds(null, pageable);
+    var result = service.findMostViewedArtikkeliErcs(null, pageable);
 
     assertEquals(0, result.maara());
     assertTrue(result.sisalto().isEmpty());

--- a/src/test/java/fi/okm/jod/ohjaaja/service/ArtikkelinKommenttiModerointiServiceTest.java
+++ b/src/test/java/fi/okm/jod/ohjaaja/service/ArtikkelinKommenttiModerointiServiceTest.java
@@ -33,7 +33,8 @@ class ArtikkelinKommenttiModerointiServiceTest extends AbstractServiceTest {
   void shouldReturnEmptyListWhenNoIlmianto() {
 
     var ohjaaja = entityManager.find(Ohjaaja.class, user.getId());
-    entityManager.persist(new ArtikkelinKommentti(ohjaaja, 1L, "Test Comment"));
+    entityManager.persist(
+        new ArtikkelinKommentti(ohjaaja, "external-reference-code", "Test Comment"));
 
     var ilmianto = service.getAllIlmiantoYhteenveto();
     assertTrue(ilmianto.isEmpty(), "Expected no ilmianto to be returned");
@@ -43,7 +44,9 @@ class ArtikkelinKommenttiModerointiServiceTest extends AbstractServiceTest {
   void shouldReturnOneIlmiantoYhteenvetoWhenThereIsOnlyOneAnonymousIlmianto() {
 
     var ohjaaja = entityManager.find(Ohjaaja.class, user.getId());
-    var kommentti = entityManager.persist(new ArtikkelinKommentti(ohjaaja, 1L, "Test Comment"));
+    var kommentti =
+        entityManager.persist(
+            new ArtikkelinKommentti(ohjaaja, "external-reference-code", "Test Comment"));
 
     ilmiantoRepository.upsertIlmianto(kommentti.getId(), false);
 
@@ -67,7 +70,9 @@ class ArtikkelinKommenttiModerointiServiceTest extends AbstractServiceTest {
   void shouldReturnOneIlmiantoYhteenvetoWhenThereIsOneAnonymousAndOneAuthenticatedIlmianto() {
 
     var ohjaaja = entityManager.find(Ohjaaja.class, user.getId());
-    var kommentti = entityManager.persist(new ArtikkelinKommentti(ohjaaja, 1L, "Test Comment"));
+    var kommentti =
+        entityManager.persist(
+            new ArtikkelinKommentti(ohjaaja, "external-reference-code", "Test Comment"));
 
     ilmiantoRepository.upsertIlmianto(kommentti.getId(), false);
     ilmiantoRepository.upsertIlmianto(kommentti.getId(), true);

--- a/src/test/java/fi/okm/jod/ohjaaja/service/profiili/OhjaajanSuosikkiServiceTest.java
+++ b/src/test/java/fi/okm/jod/ohjaaja/service/profiili/OhjaajanSuosikkiServiceTest.java
@@ -30,8 +30,8 @@ class OhjaajanSuosikkiServiceTest extends AbstractServiceTest {
   @WithMockUser
   void shoudAddOhjaajanSuosikki() throws AssertionFailure {
 
-    final Long artikkeliId = 123L;
-    var newId = service.add(user, artikkeliId);
+    final String artikkeliErc = "external-reference-code";
+    var newId = service.add(user, artikkeliErc);
     var suosikit = service.findAll(user);
 
     assertEquals(1, suosikit.size());
@@ -39,15 +39,15 @@ class OhjaajanSuosikkiServiceTest extends AbstractServiceTest {
     assertNotNull(suosikki.id());
     assertEquals(newId, suosikki.id());
     assertNotNull(suosikki.luotu());
-    assertEquals(artikkeliId, suosikki.artikkeliId());
+    assertEquals(artikkeliErc, suosikki.artikkeliErc());
   }
 
   @Test
   @WithMockUser
   void shouldNotAddSameDataTwice() throws AssertionFailure {
-    final Long artikkeliId = 123L;
-    var newId = service.add(user, artikkeliId);
-    var newId2 = service.add(user, artikkeliId);
+    final String artikkeliErc = "external-reference-code";
+    var newId = service.add(user, artikkeliErc);
+    var newId2 = service.add(user, artikkeliErc);
     assertEquals(newId, newId2);
 
     var suosikit = service.findAll(user);
@@ -57,12 +57,12 @@ class OhjaajanSuosikkiServiceTest extends AbstractServiceTest {
   @Test
   @WithMockUser
   void shouldRemoveOhjaajanSuosikki() throws AssertionFailure {
-    final Long artikkeliId1 = 1123L;
-    final Long artikkeliId2 = 2123L;
-    final Long artikkeliId3 = 3123L;
-    var newId1 = service.add(user, artikkeliId1);
-    var newId2 = service.add(user, artikkeliId2);
-    var newId3 = service.add(user, artikkeliId3);
+    final String artikkeliErc1 = "external-reference-code1";
+    final String artikkeliErc2 = "external-reference-code2";
+    final String artikkeliErc3 = "external-reference-code3";
+    var newId1 = service.add(user, artikkeliErc1);
+    var newId2 = service.add(user, artikkeliErc2);
+    var newId3 = service.add(user, artikkeliErc3);
     var suosikitBeforeDelete = service.findAll(user);
 
     assertEquals(3, suosikitBeforeDelete.size());


### PR DESCRIPTION
### Description
Replace all references to Artikkeli so that they use articleECR (string) instead of articleId (long)

### Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-1924
